### PR TITLE
Fix: add some space at the bottom of the tiles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -157,6 +157,7 @@ html, body
       display: grid
       grid-template-columns: repeat(2, 1fr)
       grid-gap: .4rem
+      margin-bottom: 60px
 
     padding: .4rem
     flex: 4


### PR DESCRIPTION
Add some bottom margin to ensure the percentage is always visible in the tile footer.

![Fix screenshot](https://user-images.githubusercontent.com/7600265/116973794-57658700-acbd-11eb-8d4f-5f69f83a6b44.png)
